### PR TITLE
create: Add package alias with no @ prefix

### DIFF
--- a/packages/cli/src/commands/build-all-private/action.ts
+++ b/packages/cli/src/commands/build-all-private/action.ts
@@ -23,6 +23,7 @@ export async function action(): Promise<void> {
   // group.
   const secondGroup = [
     'create',
+    'create-alias',
     'create-plugin',
     // 'cloud',
     'lambda',

--- a/packages/create-alias/bin/create.mjs
+++ b/packages/create-alias/bin/create.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { create } from '../dist/index.js';
+create.parse();

--- a/packages/create-alias/package.json
+++ b/packages/create-alias/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rapidstack-create",
+  "name": "@rapidstack/create",
   "version": "0.0.0",
   "license": "MIT",
   "type": "module",

--- a/packages/create-alias/src/index.ts
+++ b/packages/create-alias/src/index.ts
@@ -1,0 +1,2 @@
+import { buildCreateCommand } from '@rapidstack/cli/create';
+export const create = buildCreateCommand();

--- a/packages/create-alias/tsconfig.build.json
+++ b/packages/create-alias/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist"
+  },
+  "exclude": ["**/*.test.ts"],
+  "include": ["src"]
+}

--- a/packages/create-alias/tsconfig.json
+++ b/packages/create-alias/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../tsconfig.json", "exclude": ["dist"] }

--- a/packages/create-alias/tsup.config.ts
+++ b/packages/create-alias/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+import { sharedTsupConfig } from '../../tsup.config.js';
+
+export default defineConfig({
+  ...sharedTsupConfig,
+  dts: false,
+  format: ['esm'],
+});

--- a/packages/create-alias/vitest.config.ts
+++ b/packages/create-alias/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
     },
-    name: '@rapidstack/create',
+    name: '@rapidstack/create (alias)',
     passWithNoTests: true,
   },
 });

--- a/packages/create-alias/vitest.config.ts
+++ b/packages/create-alias/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+    name: '@rapidstack/create',
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,12 @@ importers:
         specifier: workspace:*
         version: link:../cli
 
+  packages/create-alias:
+    dependencies:
+      '@rapidstack/cli':
+        specifier: workspace:*
+        version: link:../cli
+
   packages/create-plugin:
     dependencies:
       '@rapidstack/cli':


### PR DESCRIPTION
Projects can now be initializes with the following commands/packages
```sh
npm init @rapidstack
```
```sh
npm init rapidstack
```